### PR TITLE
Add runtime resource attributes, span status/kind, and fix ODR singletons

### DIFF
--- a/include/OtelDefaults.h
+++ b/include/OtelDefaults.h
@@ -149,22 +149,27 @@ inline OTelResourceConfig& defaultResource() {
  * Merges runtime defaultResource() values with compile-time fallbacks.
  * Runtime values always win over fallbacks.
  */
-static inline void buildResourceAttributes(JsonArray& attrs,
+inline void buildResourceAttributes(JsonArray& attrs,
     const String& fallbackServiceName,
     const String& fallbackInstanceId,
     const String& fallbackHostName)
 {
+    // Pre-constructed keys to avoid per-call temporary String heap allocations
+    static const String kServiceName("service.name");
+    static const String kServiceInstanceId("service.instance.id");
+    static const String kHostName("host.name");
+
     const auto& res = defaultResource();
 
     // Add compile-time fallbacks only for keys not set at runtime
-    if (res.attrs.find("service.name") == res.attrs.end()) {
-        serializeKeyValue(attrs, "service.name", fallbackServiceName);
+    if (res.attrs.find(kServiceName) == res.attrs.end()) {
+        serializeKeyValue(attrs, kServiceName, fallbackServiceName);
     }
-    if (res.attrs.find("service.instance.id") == res.attrs.end()) {
-        serializeKeyValue(attrs, "service.instance.id", fallbackInstanceId);
+    if (res.attrs.find(kServiceInstanceId) == res.attrs.end()) {
+        serializeKeyValue(attrs, kServiceInstanceId, fallbackInstanceId);
     }
-    if (res.attrs.find("host.name") == res.attrs.end()) {
-        serializeKeyValue(attrs, "host.name", fallbackHostName);
+    if (res.attrs.find(kHostName) == res.attrs.end()) {
+        serializeKeyValue(attrs, kHostName, fallbackHostName);
     }
 
     // Add all runtime resource attributes (overrides included)

--- a/include/OtelDefaults.h
+++ b/include/OtelDefaults.h
@@ -150,32 +150,32 @@ inline OTelResourceConfig& defaultResource() {
  * Runtime values always win over fallbacks.
  */
 inline void buildResourceAttributes(JsonArray& attrs,
-    const String& fallbackServiceName,
-    const String& fallbackInstanceId,
-    const String& fallbackHostName)
+  const String& fallbackServiceName,
+  const String& fallbackInstanceId,
+  const String& fallbackHostName)
 {
-    // Pre-constructed keys to avoid per-call temporary String heap allocations
-    static const String kServiceName("service.name");
-    static const String kServiceInstanceId("service.instance.id");
-    static const String kHostName("host.name");
+  // Pre-constructed keys to avoid per-call temporary String heap allocations
+  static const String kServiceName("service.name");
+  static const String kServiceInstanceId("service.instance.id");
+  static const String kHostName("host.name");
 
-    const auto& res = defaultResource();
+  const auto& res = defaultResource();
 
-    // Add compile-time fallbacks only for keys not set at runtime
-    if (res.attrs.find(kServiceName) == res.attrs.end()) {
-        serializeKeyValue(attrs, kServiceName, fallbackServiceName);
-    }
-    if (res.attrs.find(kServiceInstanceId) == res.attrs.end()) {
-        serializeKeyValue(attrs, kServiceInstanceId, fallbackInstanceId);
-    }
-    if (res.attrs.find(kHostName) == res.attrs.end()) {
-        serializeKeyValue(attrs, kHostName, fallbackHostName);
-    }
+  // Add compile-time fallbacks only for keys not set at runtime
+  if (res.attrs.find(kServiceName) == res.attrs.end()) {
+    serializeKeyValue(attrs, kServiceName, fallbackServiceName);
+  }
+  if (res.attrs.find(kServiceInstanceId) == res.attrs.end()) {
+    serializeKeyValue(attrs, kServiceInstanceId, fallbackInstanceId);
+  }
+  if (res.attrs.find(kHostName) == res.attrs.end()) {
+    serializeKeyValue(attrs, kHostName, fallbackHostName);
+  }
 
-    // Add all runtime resource attributes (overrides included)
-    for (const auto& p : res.attrs) {
-        serializeKeyValue(attrs, p.first, p.second);
-    }
+  // Add all runtime resource attributes (overrides included)
+  for (const auto& p : res.attrs) {
+    serializeKeyValue(attrs, p.first, p.second);
+  }
 }
 
 } // namespace OTel

--- a/include/OtelDefaults.h
+++ b/include/OtelDefaults.h
@@ -138,11 +138,40 @@ struct OTelResourceConfig {
 // -------------------------------------------------------------------------------------------------
 
 /** Default resource for general use (metrics/logs/etc.) */
-static inline OTelResourceConfig& defaultResource() {
+inline OTelResourceConfig& defaultResource() {
   static OTelResourceConfig rc;
   return rc;
 }
 
+
+/**
+ * Build resource attributes into an OTLP JSON attributes array.
+ * Merges runtime defaultResource() values with compile-time fallbacks.
+ * Runtime values always win over fallbacks.
+ */
+static inline void buildResourceAttributes(JsonArray& attrs,
+    const String& fallbackServiceName,
+    const String& fallbackInstanceId,
+    const String& fallbackHostName)
+{
+    const auto& res = defaultResource();
+
+    // Add compile-time fallbacks only for keys not set at runtime
+    if (res.attrs.find("service.name") == res.attrs.end()) {
+        serializeKeyValue(attrs, "service.name", fallbackServiceName);
+    }
+    if (res.attrs.find("service.instance.id") == res.attrs.end()) {
+        serializeKeyValue(attrs, "service.instance.id", fallbackInstanceId);
+    }
+    if (res.attrs.find("host.name") == res.attrs.end()) {
+        serializeKeyValue(attrs, "host.name", fallbackHostName);
+    }
+
+    // Add all runtime resource attributes (overrides included)
+    for (const auto& p : res.attrs) {
+        serializeKeyValue(attrs, p.first, p.second);
+    }
+}
 
 } // namespace OTel
 

--- a/include/OtelLogger.h
+++ b/include/OtelLogger.h
@@ -28,13 +28,13 @@ struct LogScopeConfig {
   String scopeName{"otel-embedded-cpp"};
   String scopeVersion{""}; // optional
 };
-static inline LogScopeConfig& logScopeConfig() {
+inline LogScopeConfig& logScopeConfig() {
   static LogScopeConfig cfg;
   return cfg;
 }
 
 // ---- Default labels (merged into each log record's attributes) --------------
-static inline std::map<String, String>& defaultLabels() {
+inline std::map<String, String>& defaultLabels() {
   static std::map<String, String> labels;
   return labels;
 }
@@ -91,9 +91,7 @@ private:
     // Resource (with attributes to ensure service.name lands)
     JsonObject resource = rl["resource"].to<JsonObject>();
     JsonArray rattrs = resource["attributes"].to<JsonArray>();
-    addResAttr(rattrs, "service.name",        defaultServiceName());
-    addResAttr(rattrs, "service.instance.id", defaultServiceInstanceId());
-    addResAttr(rattrs, "host.name",           defaultHostName());
+    buildResourceAttributes(rattrs, defaultServiceName(), defaultServiceInstanceId(), defaultHostName());
 
     // Scope
     JsonObject sl = rl["scopeLogs"].to<JsonArray>().add<JsonObject>();

--- a/include/OtelLogger.h
+++ b/include/OtelLogger.h
@@ -8,7 +8,7 @@
 #include <ArduinoJson.h>
 #include "OtelDefaults.h"   // expects: nowUnixNano()
 #include "OtelSender.h"     // expects: OTelSender::sendJson(path, doc)
-#include "OtelTracer.h"     // provides: currentTraceContext(), u64ToStr(), defaults & addResAttr helpers
+#include "OtelTracer.h"     // provides: currentTraceContext(), u64ToStr(), defaults
 
 namespace OTel {
 

--- a/include/OtelMetrics.h
+++ b/include/OtelMetrics.h
@@ -18,13 +18,13 @@ struct MetricsScopeConfig {
   String scopeVersion{"0.1.0"};
 };
 
-static inline MetricsScopeConfig& metricsScopeConfig() {
+inline MetricsScopeConfig& metricsScopeConfig() {
   static MetricsScopeConfig cfg;
   return cfg;
 }
 
 // ---- Default metric labels (merged into each datapoint's attributes) --------
-static inline std::map<String, String>& defaultMetricLabels() {
+inline std::map<String, String>& defaultMetricLabels() {
   static std::map<String, String> labels;
   return labels;
 }

--- a/include/OtelMetrics.h
+++ b/include/OtelMetrics.h
@@ -8,7 +8,7 @@
 #include <ArduinoJson.h>
 #include "OtelDefaults.h"   // expects: nowUnixNano()
 #include "OtelSender.h"     // expects: OTelSender::sendJson(path, doc)
-#include "OtelTracer.h"     // reuses: u64ToStr(), defaultServiceName(), defaultServiceInstanceId(), defaultHostName(), addResAttr()
+#include "OtelTracer.h"     // reuses: u64ToStr(), defaultServiceName(), defaultServiceInstanceId(), defaultHostName()
 
 namespace OTel {
 

--- a/include/OtelTracer.h
+++ b/include/OtelTracer.h
@@ -405,11 +405,20 @@ static inline String generateSpanId() {
 
 
 
-// Add one string attribute to a resource attributes array
-static inline void addResAttr(JsonArray& arr, const char* key, const String& value) {
-  JsonObject a = arr.add<JsonObject>();
-  a["key"] = key;
-  a["value"].to<JsonObject>()["stringValue"] = value;
+// ---- OTLP SpanKind constants ------------------------------------------------
+namespace SpanKind {
+  constexpr int INTERNAL = 1;
+  constexpr int SERVER   = 2;
+  constexpr int CLIENT   = 3;
+  constexpr int PRODUCER = 4;
+  constexpr int CONSUMER = 5;
+}
+
+// ---- OTLP StatusCode constants ----------------------------------------------
+namespace StatusCode {
+  constexpr int UNSET = 0;
+  constexpr int OK    = 1;
+  constexpr int ERROR = 2;
 }
 
 // ---- Tracer configuration ---------------------------------------------------
@@ -493,33 +502,29 @@ public:
   }
 
   // ---------- Span status (OTLP StatusCode) -----------------------------------
-  // UNSET=0, OK=1, ERROR=2
   Span& setStatus(int code, const String& message = "") {
-    // Clamp to valid OTLP StatusCode range to ensure spec-compliant payloads.
-    if (code < 0) {
-      statusCode_ = 0;  // UNSET
-    } else if (code > 2) {
-      statusCode_ = 2;  // ERROR
-    } else {
+    if (code >= StatusCode::UNSET && code <= StatusCode::ERROR) {
       statusCode_ = code;
+    } else {
+      statusCode_ = StatusCode::UNSET;
+      Serial.printf("[otel] WARNING: invalid status code %d, defaulting to UNSET\n", code);
     }
     statusMessage_ = message;
     return *this;
   }
   Span& setError(const String& message = "") {
-    return setStatus(2, message);
+    return setStatus(StatusCode::ERROR, message);
   }
   Span& setOk() {
-    return setStatus(1);
+    return setStatus(StatusCode::OK);
   }
 
   // ---------- Span kind (OTLP SpanKind) --------------------------------------
-  // INTERNAL=1, SERVER=2, CLIENT=3, PRODUCER=4, CONSUMER=5
   Span& setKind(int kind) {
-    // Validate input to avoid emitting invalid OTLP SpanKind values.
-    // Only update kind_ if the provided value is within the allowed range.
-    if (kind >= 1 && kind <= 5) {
+    if (kind >= SpanKind::INTERNAL && kind <= SpanKind::CONSUMER) {
       kind_ = kind;
+    } else {
+      Serial.printf("[otel] WARNING: invalid span kind %d, keeping SERVER\n", kind);
     }
     return *this;
   }
@@ -659,10 +664,11 @@ public:
     }
 
     // Span status (only serialise if explicitly set)
-    if (statusCode_ != 0) {
+    if (statusCode_ != StatusCode::UNSET) {
       JsonObject status = s["status"].to<JsonObject>();
       status["code"] = statusCode_;
-      if (statusCode_ == 2 && statusMessage_.length() > 0) {
+      // Per OTLP spec, message is only meaningful for ERROR status
+      if (statusCode_ == StatusCode::ERROR && statusMessage_.length() > 0) {
         status["message"] = statusMessage_;
       }
     }
@@ -680,13 +686,6 @@ public:
   const String& spanId()  const { return spanId_;  }
 
 private:
-  // Utility to add a resource attribute
-  static inline void addResAttr(JsonArray& arr, const char* key, const String& val) {
-    JsonObject a = arr.add<JsonObject>();
-    a["key"] = key;
-    a["value"]["stringValue"] = val;
-  }
-
   static inline String u64ToStr(uint64_t v) {
     // Avoid ambiguous Arduino String(uint64_t) by formatting manually
     char buf[32];

--- a/include/OtelTracer.h
+++ b/include/OtelTracer.h
@@ -651,7 +651,7 @@ public:
     if (statusCode_ != 0) {
       JsonObject status = s["status"].to<JsonObject>();
       status["code"] = statusCode_;
-      if (statusMessage_.length() > 0) {
+      if (statusCode_ == 2 && statusMessage_.length() > 0) {
         status["message"] = statusMessage_;
       }
     }

--- a/include/OtelTracer.h
+++ b/include/OtelTracer.h
@@ -405,6 +405,15 @@ static inline String generateSpanId() {
 
 
 
+// ---- Deprecated: use buildResourceAttributes() instead ----------------------
+// Kept for backwards compatibility with existing user code.
+[[deprecated("Use buildResourceAttributes() instead")]]
+static inline void addResAttr(JsonArray& arr, const char* key, const String& value) {
+  JsonObject a = arr.add<JsonObject>();
+  a["key"] = key;
+  a["value"].to<JsonObject>()["stringValue"] = value;
+}
+
 // ---- OTLP SpanKind constants ------------------------------------------------
 namespace SpanKind {
   constexpr int INTERNAL = 1;

--- a/include/OtelTracer.h
+++ b/include/OtelTracer.h
@@ -516,7 +516,7 @@ public:
       statusCode_ = code;
     } else {
       statusCode_ = StatusCode::UNSET;
-      Serial.printf("[otel] WARNING: invalid status code %d, defaulting to UNSET\n", code);
+      DBG_PRINT("[otel] WARNING: invalid status code "); DBG_PRINT(code); DBG_PRINTLN(", defaulting to UNSET");
     }
     statusMessage_ = message;
     return *this;
@@ -533,7 +533,8 @@ public:
     if (kind >= SpanKind::INTERNAL && kind <= SpanKind::CONSUMER) {
       kind_ = kind;
     } else {
-      Serial.printf("[otel] WARNING: invalid span kind %d, keeping SERVER\n", kind);
+      DBG_PRINT("[otel] WARNING: invalid span kind "); DBG_PRINT(kind);
+      DBG_PRINT(", keeping previous kind ("); DBG_PRINT(kind_); DBG_PRINTLN(")");
     }
     return *this;
   }
@@ -733,8 +734,8 @@ private:
   std::vector<Event> events_;
 
   // Span kind and status
-  int kind_ = 2;          // SERVER by default
-  int statusCode_ = 0;    // UNSET=0, OK=1, ERROR=2
+  int kind_ = SpanKind::SERVER;
+  int statusCode_ = StatusCode::UNSET;
   String statusMessage_;
 
   // RAII guard

--- a/include/OtelTracer.h
+++ b/include/OtelTracer.h
@@ -30,7 +30,7 @@ struct TraceContext {
   bool valid() const { return traceId.length() == 32 && spanId.length() == 16; }
 };
 
-static inline TraceContext& currentTraceContext() {
+inline TraceContext& currentTraceContext() {
   static TraceContext ctx;
   return ctx;
 }
@@ -418,7 +418,7 @@ struct TracerConfig {
   String scopeVersion{"0.1.0"};
 };
 
-static inline TracerConfig& tracerConfig() {
+inline TracerConfig& tracerConfig() {
   static TracerConfig cfg;
   return cfg;
 }
@@ -460,6 +460,9 @@ public:
     prevSpanId_(std::move(o.prevSpanId_)),
     attrs_(std::move(o.attrs_)),
     events_(std::move(o.events_)),
+    kind_(o.kind_),
+    statusCode_(o.statusCode_),
+    statusMessage_(std::move(o.statusMessage_)),
     ended_(o.ended_)
   {
     o.ended_ = true;          // source dtor becomes a no-op
@@ -478,6 +481,9 @@ public:
       prevSpanId_  = std::move(o.prevSpanId_);
       attrs_       = std::move(o.attrs_);
       events_      = std::move(o.events_);
+      kind_        = o.kind_;
+      statusCode_  = o.statusCode_;
+      statusMessage_ = std::move(o.statusMessage_);
       ended_       = o.ended_;
       o.ended_     = true;    // source won't end() again
       o.prevTraceId_ = "";
@@ -486,7 +492,28 @@ public:
     return *this;
   }
 
-  // ---------- NEW: span attributes API ---------------------------------------
+  // ---------- Span status (OTLP StatusCode) -----------------------------------
+  // UNSET=0, OK=1, ERROR=2
+  Span& setStatus(int code, const String& message = "") {
+    statusCode_ = code;
+    statusMessage_ = message;
+    return *this;
+  }
+  Span& setError(const String& message = "") {
+    return setStatus(2, message);
+  }
+  Span& setOk() {
+    return setStatus(1);
+  }
+
+  // ---------- Span kind (OTLP SpanKind) --------------------------------------
+  // INTERNAL=1, SERVER=2, CLIENT=3, PRODUCER=4, CONSUMER=5
+  Span& setKind(int kind) {
+    kind_ = kind;
+    return *this;
+  }
+
+  // ---------- Span attributes API --------------------------------------------
   // These buffer attributes until end() and are rendered into OTLP JSON.
   Span& setAttribute(const String& key, const String& v) {
     //attrs_.push_back(Attr{key, Type::Str, v, 0, 0.0, false});
@@ -558,9 +585,7 @@ public:
 
     // resourceSpans[0].resource.attributes[...]
     JsonArray rattrs = doc["resourceSpans"][0]["resource"]["attributes"].to<JsonArray>();
-    addResAttr(rattrs, "service.name",        defaultServiceName());
-    addResAttr(rattrs, "service.instance.id", defaultServiceInstanceId());
-    addResAttr(rattrs, "host.name",           defaultHostName());
+    buildResourceAttributes(rattrs, defaultServiceName(), defaultServiceInstanceId(), defaultHostName());
 
     // instrumentation scope
     JsonObject scope = doc["resourceSpans"][0]["scopeSpans"][0]["scope"].to<JsonObject>();
@@ -572,7 +597,7 @@ public:
     s["traceId"]           = traceId_;
     s["spanId"]            = spanId_;
     s["name"]              = name_;
-    s["kind"]              = 2; // SERVER by default; adjust if you have a setter
+    s["kind"]              = kind_;
     s["startTimeUnixNano"] = u64ToStr(startNs_);
     s["endTimeUnixNano"]   = u64ToStr(endNs);
 
@@ -619,6 +644,15 @@ public:
             }
           }
         }
+      }
+    }
+
+    // Span status (only serialise if explicitly set)
+    if (statusCode_ != 0) {
+      JsonObject status = s["status"].to<JsonObject>();
+      status["code"] = statusCode_;
+      if (statusMessage_.length() > 0) {
+        status["message"] = statusMessage_;
       }
     }
 
@@ -675,9 +709,14 @@ private:
   String prevTraceId_;
   String prevSpanId_;
 
-  // NEW: buffers
+  // Buffers
   std::vector<Attr>  attrs_;
   std::vector<Event> events_;
+
+  // Span kind and status
+  int kind_ = 2;          // SERVER by default
+  int statusCode_ = 0;    // UNSET=0, OK=1, ERROR=2
+  String statusMessage_;
 
   // RAII guard
   bool ended_ = false;

--- a/include/OtelTracer.h
+++ b/include/OtelTracer.h
@@ -509,7 +509,11 @@ public:
   // ---------- Span kind (OTLP SpanKind) --------------------------------------
   // INTERNAL=1, SERVER=2, CLIENT=3, PRODUCER=4, CONSUMER=5
   Span& setKind(int kind) {
-    kind_ = kind;
+    // Validate input to avoid emitting invalid OTLP SpanKind values.
+    // Only update kind_ if the provided value is within the allowed range.
+    if (kind >= 1 && kind <= 5) {
+      kind_ = kind;
+    }
     return *this;
   }
 

--- a/include/OtelTracer.h
+++ b/include/OtelTracer.h
@@ -495,7 +495,14 @@ public:
   // ---------- Span status (OTLP StatusCode) -----------------------------------
   // UNSET=0, OK=1, ERROR=2
   Span& setStatus(int code, const String& message = "") {
-    statusCode_ = code;
+    // Clamp to valid OTLP StatusCode range to ensure spec-compliant payloads.
+    if (code < 0) {
+      statusCode_ = 0;  // UNSET
+    } else if (code > 2) {
+      statusCode_ = 2;  // ERROR
+    } else {
+      statusCode_ = code;
+    }
     statusMessage_ = message;
     return *this;
   }

--- a/src/OtelMetrics.cpp
+++ b/src/OtelMetrics.cpp
@@ -21,9 +21,7 @@ static void addPointAttributes(JsonArray& attrArray,
 
 static void addCommonResource(JsonObject& resource) {
   JsonArray rattrs = resource["attributes"].to<JsonArray>();
-  addResAttr(rattrs, "service.name",        defaultServiceName());
-  addResAttr(rattrs, "service.instance.id", defaultServiceInstanceId());
-  addResAttr(rattrs, "host.name",           defaultHostName());
+  buildResourceAttributes(rattrs, defaultServiceName(), defaultServiceInstanceId(), defaultHostName());
 }
 
 static void addCommonScope(JsonObject& scope) {


### PR DESCRIPTION
## Summary

- **Fix singleton ODR violation**: All singleton accessor functions (`defaultResource`, `currentTraceContext`, `tracerConfig`, etc.) were `static inline`, giving each translation unit its own copy. Changed to `inline` so state is shared across TUs — without this, runtime resource attributes set in one `.cpp` were invisible to signal builders in others.

- **Runtime resource attributes**: Added `buildResourceAttributes()` that merges `defaultResource()` values with compile-time fallbacks. All signal types (traces, metrics, logs) now use this, allowing callers to set `service.name`, `service.namespace`, `service.instance.id` etc. at runtime.

- **Span status and kind API**: Added `setStatus(code, msg)`, `setError(msg)`, `setOk()` for OTLP StatusCode and `setKind(kind)` for SpanKind. Previously kind was hardcoded to SERVER and status was always UNSET, preventing proper error detection and span classification in backends like Dash0/Grafana.

## Test plan

- [x] Builds successfully on ESP32 and ESP8266
- [x] Verified runtime resource attributes appear on traces, logs, and metrics in Dash0
- [x] Verified span status ERROR shows correctly for error spans
- [x] Verified span kind INTERNAL/CONSUMER classification works
- [ ] Backward compatible — existing code that doesn't call the new APIs gets the same defaults as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Spans can record status (code + optional message), mark explicit success, report errors, and set an explicit span kind.
  * New exported span-kind and status-code constants for clearer telemetry semantics.

* **Improvements**
  * Resource attribute assembly consolidated for more consistent telemetry exports.
  * Span serialization now emits status only when set, reducing noise in exported spans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->