### PR TITLE
feat(metrics): Use default resource labels for metrics.

### DIFF
--- a/include/OtelDefaults.h
+++ b/include/OtelDefaults.h
@@ -138,13 +138,11 @@ struct OTelResourceConfig {
 // -------------------------------------------------------------------------------------------------
 
 /** Default resource for general use (metrics/logs/etc.) */
-static inline OTelResourceConfig& defaultResource() {
+inline OTelResourceConfig& defaultResource() {
   static OTelResourceConfig rc;
   return rc;
 }
 
-
 } // namespace OTel
 
 #endif // OTEL_DEFAULTS_H
-

--- a/src/OtelMetrics.cpp
+++ b/src/OtelMetrics.cpp
@@ -20,6 +20,12 @@ static void addPointAttributes(JsonArray& attrArray,
 }
 
 static void addCommonResource(JsonObject& resource) {
+  auto &res = OTel::defaultResource();
+  if (!res.attrs.empty()) {
+    res.addResourceAttributes(resource);
+    return;
+  }
+
   JsonArray rattrs = resource["attributes"].to<JsonArray>();
   addResAttr(rattrs, "service.name",        defaultServiceName());
   addResAttr(rattrs, "service.instance.id", defaultServiceInstanceId());

--- a/src/OtelMetrics.cpp
+++ b/src/OtelMetrics.cpp
@@ -21,7 +21,7 @@ static void addPointAttributes(JsonArray& attrArray,
 
 static void addCommonResource(JsonObject& resource) {
   auto &res = OTel::defaultResource();
-  if (!res.attrs.empty()) {
+  if (!res.empty()) {
     res.addResourceAttributes(resource);
     return;
   }


### PR DESCRIPTION
Previously, metrics were reported without the resource labels set via `defaultResource().set()`, using a set of built-in defaults (`service.name`, `service.instance.id`, and `host.name`) instead.

This changes the behavior if default resource labels are set and uses those resource labels instead. If no default resource labels are set, the previous behavior is retained for (limited) backwards compatibility.

Note on implementation: The `static` keyword was removed from `defaultResource()` to enable correct linking. With `static`, each compilation unit allocates its own set of resource labels, which is not intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resource handling now correctly prioritises configured default resource attributes during initialisation. When defaults are present they are merged into the resource; when not present the system falls back to the standard service name, instance ID and hostname attributes to preserve prior behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->